### PR TITLE
Add support for flarum/flags, fix issue creating group-only pds

### DIFF
--- a/js/src/admin/addPrivateDiscussionPermission.js
+++ b/js/src/admin/addPrivateDiscussionPermission.js
@@ -30,5 +30,10 @@ export default function () {
             label: app.translator.trans('fof-byobu.admin.permission.edit_group_recipients'),
             permission: 'discussion.editGroupRecipients'
         }, 95);
+        items.add('actor-can-view-private-discussions-when-flagged', {
+            icon: 'fas fa-flag',
+            label: app.translator.trans('fof-byobu.admin.permission.view_private_discussions-when-flagged'),
+            permission: 'user.viewPrivateDiscussionsWhenFlagged'
+          }, 95);
     });
 }

--- a/migrations/2020_02_14_214800_fix_user_id_not_nullable_for_group_pds.php
+++ b/migrations/2020_02_14_214800_fix_user_id_not_nullable_for_group_pds.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('recipients', function (Blueprint $table) {
+            $table->integer('user_id')->unsigned()->nullable()->change();
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('recipients', function (Blueprint $table) {
+            $table->integer('user_id')->unsigned()->change();
+        });
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -44,6 +44,7 @@ fof-byobu:
             create_private_discussions_with_blocking_users: Create private discussions with users that block it
             edit_user_recipients: Edit users partaking in private discussions
             edit_group_recipients: Edit groups partaking in private discussions
+            view_private_discussions-when-flagged: View private discussions of other users if flagged
 
         settings:
             byobu_users_page_label: Add private discussions to user page

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -12,6 +12,7 @@
 namespace FoF\Byobu\Access;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Extension\ExtensionManager;
 use Flarum\User\AbstractPolicy;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -25,6 +26,16 @@ class DiscussionPolicy extends AbstractPolicy
     protected $model = Discussion::class;
 
     /**
+     * @var ExtensionManager
+     */
+    protected $extensions;
+
+    public function __construct(ExtensionManager $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    /**
      * @param User            $actor
      * @param EloquentBuilder $query
      */
@@ -32,19 +43,21 @@ class DiscussionPolicy extends AbstractPolicy
     {
         if ($actor->exists) {
             $query->orWhereExists(function (Builder $query) use ($actor) {
-                $prefix = $query->getConnection()->getTablePrefix();
+                $query->whereIn('id', function ($query) use ($actor) {
+                    $query->select('discussion_id')
+                        ->from('recipients')
+                        ->whereNull('removed_at')
+                        ->where('user_id', $actor->id)
+                        ->orWhereIn('group_id', $actor->groups->pluck('id')->all());
+                });
 
-                return $query->selectRaw('1')
-                    ->from('recipients')
-                    ->whereRaw($prefix.'discussions.id = discussion_id')
-                    ->whereNull('removed_at')
-                    ->where(function (Builder $query) use ($actor) {
-                        $query->where('recipients.user_id', $actor->id);
-
-                        if (!$actor->groups->isEmpty()) {
-                            $query->orWhereIn('recipients.group_id', $actor->groups->pluck('id')->all());
-                        }
+                if ($this->extensions->isEnabled('flarum-flags') && $actor->hasPermission('user.viewPrivateDiscussionsWhenFlagged')) {
+                    $query->orWhereIn('id', function ($query) {
+                        $query->select('posts.discussion_id')
+                            ->from('flags')
+                            ->leftJoin('posts', 'flags.post_id', 'posts.id');
                     });
+                }
             });
         }
     }

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -51,7 +51,11 @@ class DiscussionPolicy extends AbstractPolicy
                         ->orWhereIn('group_id', $actor->groups->pluck('id')->all());
                 });
 
-                if ($this->extensions->isEnabled('flarum-flags') && $actor->hasPermission('user.viewPrivateDiscussionsWhenFlagged')) {
+                if (
+                    $this->extensions->isEnabled('flarum-flags') &&
+                    $actor->hasPermission('user.viewPrivateDiscussionsWhenFlagged') &&
+                    $actor->hasPermission('discussion.viewFlags')
+                ) {
                     $query->orWhereIn('id', function ($query) {
                         $query->select('posts.discussion_id')
                             ->from('flags')


### PR DESCRIPTION
- new permission `viewPrivateDiscussionsWhenFlagged`
- improve efficiency of `DiscussionPolicy`
- add support for `flarum/flags` - allows mods (or whoever has the permission) to view a private discussion if it contains a flag
- fix issue where group only private discussions could not be created, due to non-nullable `user_id` column on `recipients`

Addresses #68