### PR TITLE
Fix migrations

### DIFF
--- a/migrations/2019_07_09_000000_blocks_pd_index.php
+++ b/migrations/2019_07_09_000000_blocks_pd_index.php
@@ -20,7 +20,8 @@ return [
     },
     'down' => function (Builder $schema) {
         $schema->table('users', function (Blueprint $table) {
-            $table->dropIndex('blocks_byobu_pd');
+            // Use array syntax so the blueprint "guesses" the full index name
+            $table->dropIndex(['blocks_byobu_pd']);
         });
     },
 ];

--- a/migrations/2020_02_19_110103_remove_retired_settings_key.php
+++ b/migrations/2020_02_19_110103_remove_retired_settings_key.php
@@ -12,7 +12,7 @@
 use Illuminate\Database\Schema\Builder;
 
 return [
-    'up' => function (Builder $schema) use ($permissionKey) {
+    'up' => function (Builder $schema) {
         /**
          * @var \Flarum\Settings\SettingsRepositoryInterface
          */
@@ -20,7 +20,7 @@ return [
         $settings->delete('fof-byobu.enable_byobu_user_page');
     },
 
-    'down' => function (Builder $schema) use ($permissionKey) {
+    'down' => function (Builder $schema) {
         // erm, no
     },
 ];

--- a/src/Jobs/SendNotificationWhenPrivateDiscussionStarted.php
+++ b/src/Jobs/SendNotificationWhenPrivateDiscussionStarted.php
@@ -40,7 +40,7 @@ class SendNotificationWhenPrivateDiscussionStarted implements ShouldQueue
     public function __construct(
         Discussion $discussion,
         Collection $newUsers
-        ) {
+    ) {
         $this->discussion = $discussion;
         $this->newUsers = $newUsers;
     }


### PR DESCRIPTION
First commit fixes an issue on rollback

Second commit fixes an issue when enabling the extension with notices visible.

@imorland was that undefined variable a copy-paste error or is there something else I should be aware of before merging.

```
POST http://beta12.flarum.localhost/api/extensions/fof-byobu

<br />
<b>Notice</b>:  Undefined variable: permissionKey in <b>/home/clark/Projects/flarum-beta12/vendor/fof/byobu/migrations/2020_02_19_110103_remove_retired_settings_key.php</b> on line <b>15</b><br />
<br />
<b>Notice</b>:  Undefined variable: permissionKey in <b>/home/clark/Projects/flarum-beta12/vendor/fof/byobu/migrations/2020_02_19_110103_remove_retired_settings_key.php</b> on line <b>23</b><br />
<br />
<b>Fatal error</b>:  Uncaught Laminas\HttpHandlerRunner\Exception\EmitterException: Output has been emitted previously; cannot emit response in /home/clark/Projects/flarum-beta12/vendor/laminas/laminas-httphandlerrunner/src/Exception/EmitterException.php:24
```