### PR TITLE
Prevent collapse of new PD button on mobile (#116)

### DIFF
--- a/js/src/forum/components/PrivateDiscussionsUserPage.js
+++ b/js/src/forum/components/PrivateDiscussionsUserPage.js
@@ -100,7 +100,6 @@ export default class PrivateDiscussionsUserPage extends UserPage {
                         canStartDiscussion ? 'fof-byobu.forum.nav.start_button' : 'core.forum.index.cannot_start_discussion_button'
                     ),
                     className: 'Button Button--primary IndexPage-newDiscussion',
-                    itemClassName: 'App-primaryControl',
                     onclick: this.newDiscussionAction.bind(this),
                     disabled: !canStartDiscussion,
                 })

--- a/js/src/forum/components/PrivateDiscussionsUserPage.js
+++ b/js/src/forum/components/PrivateDiscussionsUserPage.js
@@ -100,6 +100,7 @@ export default class PrivateDiscussionsUserPage extends UserPage {
                         canStartDiscussion ? 'fof-byobu.forum.nav.start_button' : 'core.forum.index.cannot_start_discussion_button'
                     ),
                     className: 'Button Button--primary IndexPage-newDiscussion',
+                    itemClassName: 'fof-byobu_primaryControl',
                     onclick: this.newDiscussionAction.bind(this),
                     disabled: !canStartDiscussion,
                 })


### PR DESCRIPTION
Removing the `App-primaryControl` class from the button fixes this issue, saving a hell of a lot of overrides in CSS, and not really affecting anything else.

Custom themes might have issues with this, as the button won't have a possibly overridden class, so style changes will need to be added manually.

Would overriding all the styles which make it collapse be better?

(Haven't built dist JS.)