### PR TITLE
Make close button visible in start PD modal on mobile (#117)

### DIFF
--- a/js/src/forum/components/AddRecipientModal.js
+++ b/js/src/forum/components/AddRecipientModal.js
@@ -77,6 +77,7 @@ export default class AddRecipientModal extends Modal {
                         {Button.component({
                             onclick: this.hide.bind(this),
                             className: 'Button Button--cancel',
+                            icon: 'fas fa-times',
                             children: app.translator.trans('fof-byobu.forum.buttons.cancel'),
                         })}
                     </div>

--- a/resources/less/forum/AddRecipientModal.less
+++ b/resources/less/forum/AddRecipientModal.less
@@ -15,6 +15,14 @@
 
 .AddRecipientModal-form-submit {
     margin-top: 1em;
+
+    .Button--cancel.hasIcon {
+        .Button-icon {
+            @media (min-width: 768px) {
+                display: none;
+            }
+        }
+    }
 }
 
 .Button--cancel {


### PR DESCRIPTION
Fixes #117 

Adds the `fas fa-times` icon to the button to make it visible on small viewports.

I'm not sure why this wasn't here in the first place, but it's here now.

## Before

![image](https://user-images.githubusercontent.com/7406822/83328441-0104f280-a27b-11ea-8df2-e4b340865b6c.png)

## After

![image](https://user-images.githubusercontent.com/7406822/83328434-f5b1c700-a27a-11ea-8702-70b03880c4ce.png)
