### PR TITLE
Removes edit recipient link on non-PD discussions

### DIFF
--- a/src/Api/DiscussionPermissionAttributes.php
+++ b/src/Api/DiscussionPermissionAttributes.php
@@ -29,7 +29,7 @@ class DiscussionPermissionAttributes
         $users = $actor->can('editUserRecipients', $model);
         $groups = $actor->can('editGroupRecipients', $model);
 
-        $attributes['canEditRecipients'] = $users || $groups;
+        $attributes['canEditRecipients'] = $model->is_private && ($users || $groups);
         $attributes['canEditUserRecipients'] = $users;
         $attributes['canEditGroupRecipients'] = $groups;
 


### PR DESCRIPTION
This removes the edit recipient control on discussions that aren't private.

Cherry-picked from one of luceos's commits.