### PR TITLE
Fixed `RecipientLabel` link being `true` instead of link to user profile

### DIFF
--- a/js/src/forum/pages/labels/RecipientLabel.tsx
+++ b/js/src/forum/pages/labels/RecipientLabel.tsx
@@ -18,7 +18,10 @@ export default class RecipientLabel extends Component<IRecipientLabelAttrs> {
 
         newAttrs.style = newAttrs.style || {};
         newAttrs.className = classList('RecipientLabel', newAttrs?.className);
-        newAttrs.href = link;
+
+        if (link) {
+            newAttrs.href = app.route.user(recipient);
+        }
 
         let label: string;
 

--- a/js/src/forum/pages/labels/RecipientLabel.tsx
+++ b/js/src/forum/pages/labels/RecipientLabel.tsx
@@ -19,7 +19,7 @@ export default class RecipientLabel extends Component<IRecipientLabelAttrs> {
         newAttrs.style = newAttrs.style || {};
         newAttrs.className = classList('RecipientLabel', newAttrs?.className);
 
-        if (link) {
+        if (link && recipient instanceof User) {
             newAttrs.href = app.route.user(recipient);
         }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #157**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Actually create a link and don't just pass `true` as `href` attr.

**Reviewers should focus on:**
If the links work fine now

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
