### PR TITLE
Support custom user sluggers and fix profile private discussions tab

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -133,6 +133,7 @@ return [
         ->checker(Listeners\GetModelIsPrivate::class),
 
     (new Extend\SimpleFlarumSearch(DiscussionSearcher::class))
+        ->addGambit(Gambits\Discussion\ByobuGambit::class)
         ->addGambit(Gambits\Discussion\PrivacyGambit::class),
 
     (new Extend\SimpleFlarumSearch(UserSearcher::class))

--- a/js/src/forum/extend/User.js
+++ b/js/src/forum/extend/User.js
@@ -61,12 +61,12 @@ function message(app) {
 
 function sharedMessageHistory(app) {
   extend(UserPage.prototype, 'navItems', function (items) {
-    const href = app.route('byobuUserPrivate', { username: this.user.username() });
+    const href = app.route('byobuUserPrivate', { username: this.user.slug() });
 
     // Hide links from guests if they are not already on the page
     if (!app.session.user && m.route.get() !== href) return;
     // Hide link for your own page.
-    if (app.session.user && app.session.user.username() === this.user.username()) return;
+    if (app.session.user === this.user) return;
 
     items.add(
       'byobu',

--- a/js/src/forum/pages/PrivateDiscussionsUserPage.js
+++ b/js/src/forum/pages/PrivateDiscussionsUserPage.js
@@ -17,7 +17,7 @@ export default class PrivateDiscussionsUserPage extends UserPage {
   show(user) {
     // We can not create the list in init because the user will not be available if it has to be loaded asynchronously
     this.list = new PrivateDiscussionListState({
-      q: `byobu:${user.username()} is:private`,
+      q: `byobu:${user.slug()} is:private`,
       sort: this.sort,
     });
 

--- a/src/Gambits/Discussion/ByobuGambit.php
+++ b/src/Gambits/Discussion/ByobuGambit.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/byobu.
  *
- * Copyright (c) 2019 - 2021 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Gambits/Discussion/ByobuGambit.php
+++ b/src/Gambits/Discussion/ByobuGambit.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) 2019 - 2021 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Gambits\Discussion;
+
+use Flarum\Http\SlugManager;
+use Flarum\Search\AbstractRegexGambit;
+use Flarum\Search\SearchState;
+use Flarum\User\User;
+use FoF\Byobu\Database\RecipientsConstraint;
+
+/**
+ * Filters results to discussions that include the given user as recipient. Used to show private discussions on a user profile.
+ */
+class ByobuGambit extends AbstractRegexGambit
+{
+    use RecipientsConstraint;
+
+    /**
+     * @var SlugManager
+     */
+    protected $slugManager;
+
+    /**
+     * @param SlugManager $slugManager
+     */
+    public function __construct(SlugManager $slugManager)
+    {
+        $this->slugManager = $slugManager;
+    }
+
+    protected function getGambitPattern(): string
+    {
+        return 'byobu:(.+)';
+    }
+
+    protected function conditions(SearchState $search, array $matches, $negate)
+    {
+        $user = $this->slugManager->forResource(User::class)->fromSlug(trim($matches[1], '"'), $search->getActor());
+
+        $search->getQuery()->where(function ($query) use ($user) {
+            $this->forRecipient($query, [], $user->id);
+        });
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
The main goal of this PR was to add support for custom user sluggers, in particular Flarum's built-in ID-based slugger, following this request https://discuss.flarum.org/d/4762-friendsofflarum-by-bu-well-integrated-advanced-private-discussions/1119

However in the process I also discovered that the private discussions profile tab just didn't seem to work anymore since v1.0 of Byobu, because the gambit it uses was removed. I have re-added the gambit and used a method from the existing trait to not duplicate any logic.

**Reviewers should focus on:**
- Do we still want the private discussions page on the profile so it it worth fixing it?
- Do we need backward compatibility with how the `byobu` search gambit worked? I have dropped support for multiple usernames in a single query, and now it will no longer work with usernames if the user slugger is switched because it uses the slugger to convert the value
- Should the `forRecipient()` trait method be made `public` since it's now used directly from elsewhere? (it's `protected`)
- We could rename the route parameter from `username` to `slug`, but Flarum core also kept its profile route parameters named `username` so I think it's more logical to keep it as-it, and just pass the slug value to the parameter

I wasn't 100% sure what the page on the user profile was actually supposed to do. I guess it makes sense to list all private discussions we have with that particular user, without regard for whether they started the discussion or somebody else started it. But I'm not sure how it was done in 0.6, having never used the extension myself.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
