### PR TITLE
Added `recipientUsers` include for `CreateDiscussionController`

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -69,6 +69,10 @@ return [
         ->addInclude(['recipientUsers', 'recipientGroups'])
         ->load(['recipientUsers', 'recipientGroups']),
 
+    (new Extend\ApiController(Controller\CreateDiscussionController::class))
+        ->addInclude(['recipientUsers', 'recipientGroups'])
+        ->load(['recipientUsers', 'recipientGroups']),
+
     (new Extend\ApiController(Controller\ShowDiscussionController::class))
         ->addOptionalInclude(['oldRecipientUsers', 'oldRecipientGroups'])
         ->addInclude(['recipientUsers', 'recipientGroups'])


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Added `recipientUsers` include for `CreateDiscussionController`. This change has no direct effect on this extension but it fixed errors that other extensions could have because there is a discussion created in a custom way and the `recipientUsers` are not serialized, the following error might occur (see [line of code](https://github.com/FriendsOfFlarum/byobu/blob/912615946ed9d085744e0f8731974f3084ccd017/js/src/forum/extend/Discussion.js#L98)): 
```log
TypeError: e.recipientUsers().find is not a function
    Pt Discussion.js:98
```

**Reviewers should focus on:**
Nothing is broken and that this change doesn't impact performance

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
