### PR TITLE
feat: Reintroduce make public

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
             "homepage": "http://luceos.com"
         },
         {
-            "name": "Ian Morland",
-            "homepage": "https://discuss.flarum.org/u/ianm",
+            "name": "IanM",
+            "homepage": "https://blomstra.net",
             "role": "Developer"
         }
     ],

--- a/extend.php
+++ b/extend.php
@@ -115,13 +115,15 @@ return [
 
     (new Extend\Post())
         ->type(Posts\RecipientLeft::class)
-        ->type(Posts\RecipientsModified::class),
+        ->type(Posts\RecipientsModified::class)
+        ->type(Posts\MadePublic::class),
 
     (new Extend\Notification())
         ->type(Notifications\DiscussionCreatedBlueprint::class, Serializer\DiscussionSerializer::class, ['alert', 'email'])
         ->type(Notifications\DiscussionRepliedBlueprint::class, Serializer\DiscussionSerializer::class, ['alert', 'email'])
         ->type(Notifications\DiscussionRecipientRemovedBlueprint::class, Serializer\DiscussionSerializer::class, ['alert', 'email'])
-        ->type(Notifications\DiscussionAddedBlueprint::class, Serializer\DiscussionSerializer::class, ['alert', 'email']),
+        ->type(Notifications\DiscussionAddedBlueprint::class, Serializer\DiscussionSerializer::class, ['alert', 'email'])
+        ->type(Notifications\DiscussionMadePublicBlueprint::class, Serializer\DiscussionSerializer::class, ['alert']),
 
     (new Extend\Event())
         ->listen(PostSaving::class, Listeners\IgnoreApprovals::class)
@@ -144,10 +146,12 @@ return [
         ->addGambit(Gambits\User\AllowsPdGambit::class),
 
     (new Extend\Settings())
-        ->serializeToForum('byobu.icon-badge', 'fof-byobu.icon-badge', function ($value) {
+        // we have to use the callback here, else we risk returning empty values instead of the defaults.
+        // see https://github.com/flarum/core/issues/3209
+        ->serializeToForum('byobu.icon-badge', 'fof-byobu.icon-badge', function ($value): string {
             return empty($value) ? 'fas fa-map' : $value;
         })
-        ->serializeToForum('byobu.icon-postAction', 'fof-byobu.icon-postAction', function ($value) {
+        ->serializeToForum('byobu.icon-postAction', 'fof-byobu.icon-postAction', function ($value): string {
             return empty($value) ? 'far fa-map' : $value;
         }),
 ];

--- a/js/src/admin/addPrivateDiscussionPermission.ts
+++ b/js/src/admin/addPrivateDiscussionPermission.ts
@@ -1,9 +1,9 @@
 import app from 'flarum/admin/app';
 
 export default function () {
-  app.extensionData
-    .for('fof-byobu')
-    .registerPermission(
+  const byobuData = app.extensionData.for('fof-byobu');
+
+  byobuData.registerPermission(
       {
         icon: 'far fa-map',
         label: app.translator.trans('fof-byobu.admin.permission.create_private_discussions_with_users'),
@@ -63,4 +63,17 @@ export default function () {
       'moderate',
       95
     );
+    
+    if (app.data.settings['fof-byobu.makePublic']) {
+      byobuData.registerPermission(
+        {
+          icon: 'far fa-map',
+          label: app.translator.trans('fof-byobu.admin.permission.make_private_into_public'),
+          permission: 'discussion.makePublic',
+          tagScoped: false,
+        },
+        'reply',
+        95
+      );
+    }
 }

--- a/js/src/admin/addPrivateDiscussionPermission.ts
+++ b/js/src/admin/addPrivateDiscussionPermission.ts
@@ -3,7 +3,8 @@ import app from 'flarum/admin/app';
 export default function () {
   const byobuData = app.extensionData.for('fof-byobu');
 
-  byobuData.registerPermission(
+  byobuData
+    .registerPermission(
       {
         icon: 'far fa-map',
         label: app.translator.trans('fof-byobu.admin.permission.create_private_discussions_with_users'),
@@ -63,17 +64,17 @@ export default function () {
       'moderate',
       95
     );
-    
-    if (app.data.settings['fof-byobu.makePublic']) {
-      byobuData.registerPermission(
-        {
-          icon: 'far fa-map',
-          label: app.translator.trans('fof-byobu.admin.permission.make_private_into_public'),
-          permission: 'discussion.makePublic',
-          tagScoped: false,
-        },
-        'reply',
-        95
-      );
-    }
+
+  if (app.data.settings['fof-byobu.makePublic']) {
+    byobuData.registerPermission(
+      {
+        icon: 'far fa-map',
+        label: app.translator.trans('fof-byobu.admin.permission.make_private_into_public'),
+        permission: 'discussion.makePublic',
+        tagScoped: false,
+      },
+      'reply',
+      95
+    );
+  }
 }

--- a/js/src/admin/components/ByobuSettingsPage.tsx
+++ b/js/src/admin/components/ByobuSettingsPage.tsx
@@ -14,35 +14,50 @@ export default class ByobuSetingsPage extends ExtensionPage {
   }
 
   content() {
+    const helpText = flarum.extensions['flarum-tags']
+      ? app.translator.trans('flarum-tags.admin.edit_tag.icon_text', {
+          a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1" />,
+        })
+      : '';
+
     return [
-      <div className="container">
-        <div className="ByobuSettingsPage">
+      <div className="ByobuSettingsPage">
+        <div className="container">
           <div className="Form">
             <div className="Form-group">
               {this.buildSettingComponent({
                 type: 'string',
                 setting: 'fof-byobu.icon-badge',
                 label: app.translator.trans('fof-byobu.admin.settings.badge-icon'),
-                help: <Badge icon={this.setting('fof-byobu.icon-badge').toJSON() || this.badgeDefault}></Badge>,
+                help: (
+                  <div>
+                    <Badge icon={this.setting('fof-byobu.icon-badge').toJSON() || this.badgeDefault}></Badge>
+                    {' '}
+                    {helpText}
+                  </div>
+                ),
                 placeholder: this.badgeDefault,
               })}
               {this.buildSettingComponent({
                 type: 'string',
                 setting: 'fof-byobu.icon-postAction',
                 label: app.translator.trans('fof-byobu.admin.settings.post-event-icon'),
-                help: <h2>{icon(this.setting('fof-byobu.icon-postAction').toJSON() || this.postActionDefault)}</h2>,
+                help: (
+                  <div>
+                    {icon(this.setting('fof-byobu.icon-postAction').toJSON() || this.postActionDefault)}
+                    {' '}
+                    {helpText}
+                  </div>
+                ),
                 placeholder: this.postActionDefault,
               })}
+              {this.buildSettingComponent({
+                type: 'boolean',
+                setting: 'fof-byobu.makePublic',
+                label: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option'),
+                help: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option-help')
+              })}
             </div>
-            {flarum.extensions['flarum-tags'] && (
-              <div className="Form-group">
-                <p>
-                  {app.translator.trans('flarum-tags.admin.edit_tag.icon_text', {
-                    a: <a href="https://fontawesome.com/icons?m=free" tabindex="-1" />,
-                  })}
-                </p>
-              </div>
-            )}
             <div className="Form-group">{this.submitButton()}</div>
           </div>
         </div>

--- a/js/src/admin/components/ByobuSettingsPage.tsx
+++ b/js/src/admin/components/ByobuSettingsPage.tsx
@@ -31,9 +31,7 @@ export default class ByobuSetingsPage extends ExtensionPage {
                 label: app.translator.trans('fof-byobu.admin.settings.badge-icon'),
                 help: (
                   <div>
-                    <Badge icon={this.setting('fof-byobu.icon-badge').toJSON() || this.badgeDefault}></Badge>
-                    {' '}
-                    {helpText}
+                    <Badge icon={this.setting('fof-byobu.icon-badge').toJSON() || this.badgeDefault}></Badge> {helpText}
                   </div>
                 ),
                 placeholder: this.badgeDefault,
@@ -44,9 +42,7 @@ export default class ByobuSetingsPage extends ExtensionPage {
                 label: app.translator.trans('fof-byobu.admin.settings.post-event-icon'),
                 help: (
                   <div>
-                    {icon(this.setting('fof-byobu.icon-postAction').toJSON() || this.postActionDefault)}
-                    {' '}
-                    {helpText}
+                    {icon(this.setting('fof-byobu.icon-postAction').toJSON() || this.postActionDefault)} {helpText}
                   </div>
                 ),
                 placeholder: this.postActionDefault,
@@ -55,7 +51,7 @@ export default class ByobuSetingsPage extends ExtensionPage {
                 type: 'boolean',
                 setting: 'fof-byobu.makePublic',
                 label: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option'),
-                help: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option-help')
+                help: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option-help'),
               })}
             </div>
             <div className="Form-group">{this.submitButton()}</div>

--- a/js/src/forum/events/MadePublic.ts
+++ b/js/src/forum/events/MadePublic.ts
@@ -1,0 +1,16 @@
+import app from 'flarum/forum/app';
+import EventPost from 'flarum/forum/components/EventPost';
+
+export default class MadePublic extends EventPost {
+  static initAttrs(attrs: any) {
+    super.initAttrs(attrs);
+  }
+
+  icon() {
+    return app.forum.attribute('byobu.icon-postAction');
+  }
+
+  descriptionKey() {
+    return 'fof-byobu.forum.post.recipients_modified.made_public';
+  }
+}

--- a/js/src/forum/events/index.js
+++ b/js/src/forum/events/index.js
@@ -1,8 +1,10 @@
 import app from 'flarum/forum/app';
+import MadePublic from './MadePublic';
 import RecipientLeft from './RecipientLeft';
 import RecipientsModified from './RecipientsModified';
 
 export default () => {
   app.postComponents.recipientsModified = RecipientsModified;
   app.postComponents.recipientLeft = RecipientLeft;
+  app.postComponents.madePublic = MadePublic;
 };

--- a/js/src/forum/extend/Discussion.js
+++ b/js/src/forum/extend/Discussion.js
@@ -137,6 +137,25 @@ function controls() {
           app.translator.trans('fof-byobu.forum.buttons.remove_from_discussion')
         )
       );
+
+      if (discussion?.isPrivateDiscussion?.() && discussion?.canMakePublic?.()) {
+        items.add(
+          'transform-public',
+          <Button
+            icon="far fa-eye"
+            onclick={() => {
+              if (discussion && confirm(app.translator.trans('fof-byobu.forum.confirm.make_public'))) {
+                const recipientGroups = [];
+                const recipientUsers = [];
+
+                discussion.save({ relationships: { recipientUsers, recipientGroups }, public: discussion.id() }).then(() => m.redraw());
+              }
+            }}
+          >
+            {app.translator.trans('fof-byobu.forum.buttons.make_public')}
+          </Button>
+        );
+      }
     }
   });
 }
@@ -151,6 +170,7 @@ function attributes() {
   Discussion.prototype.canEditUserRecipients = Model.attribute('canEditUserRecipients');
   Discussion.prototype.canEditGroupRecipients = Model.attribute('canEditGroupRecipients');
   Discussion.prototype.canEditGroupRecipients = Model.attribute('canEditGroupRecipients');
+  Discussion.prototype.canMakePublic = Model.attribute('canMakePublic');
 
   Discussion.prototype.isPrivateDiscussion = Model.attribute('isPrivateDiscussion');
 }

--- a/js/src/forum/extend/Discussion.js
+++ b/js/src/forum/extend/Discussion.js
@@ -13,6 +13,7 @@ import recipientsLabel from '../pages/labels/recipientsLabels';
 import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 import ItemList from 'flarum/common/utils/ItemList';
 import AddRecipientModal from './../modals/AddRecipientModal';
+import TagDiscussionModal from 'flarum/tags/components/TagDiscussionModal';
 
 export default () => {
   attributes();
@@ -147,6 +148,10 @@ function controls() {
               if (discussion && confirm(app.translator.trans('fof-byobu.forum.confirm.make_public'))) {
                 const recipientGroups = [];
                 const recipientUsers = [];
+
+                if (flarum.extensions['flarum-tags']) {
+                  app.modal.show(TagDiscussionModal, { discussion });
+                }
 
                 discussion.save({ relationships: { recipientUsers, recipientGroups }, public: discussion.id() }).then(() => m.redraw());
               }

--- a/js/src/forum/extend/Discussion.js
+++ b/js/src/forum/extend/Discussion.js
@@ -13,7 +13,8 @@ import recipientsLabel from '../pages/labels/recipientsLabels';
 import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 import ItemList from 'flarum/common/utils/ItemList';
 import AddRecipientModal from './../modals/AddRecipientModal';
-import TagDiscussionModal from 'flarum/tags/components/TagDiscussionModal';
+import ByobuTagDiscussionModal from '../modals/ByobuTagDiscussionModal';
+import DiscussionPage from 'flarum/components/DiscussionPage';
 
 export default () => {
   attributes();
@@ -150,10 +151,21 @@ function controls() {
                 const recipientUsers = [];
 
                 if (flarum.extensions['flarum-tags']) {
-                  app.modal.show(TagDiscussionModal, { discussion });
+                  new Promise((resolve, reject) => {
+                    app.modal.show(ByobuTagDiscussionModal, { discussion, resolve, reject });
+                  }).then((tags) => {
+                    discussion.save({ relationships: { recipientUsers, recipientGroups }, public: discussion.id() }).then(() => {
+                      discussion.save({ relationships: { tags } }).then(() => {
+                        if (app.current.matches(DiscussionPage)) {
+                          app.current.get('stream').update();
+                        }
+                        m.redraw();
+                      });
+                    });
+                  });
+                } else {
+                  discussion.save({ relationships: { recipientUsers, recipientGroups }, public: discussion.id() }).then(() => m.redraw());
                 }
-
-                discussion.save({ relationships: { recipientUsers, recipientGroups }, public: discussion.id() }).then(() => m.redraw());
               }
             }}
           >

--- a/js/src/forum/modals/ByobuTagDiscussionModal.js
+++ b/js/src/forum/modals/ByobuTagDiscussionModal.js
@@ -1,0 +1,16 @@
+import app from 'flarum/forum/app';
+import TagDiscussionModal from 'flarum/tags/components/TagDiscussionModal';
+
+export default class ByobuTagDiscussionModal extends TagDiscussionModal {
+  static isDismissible = false;
+
+  onsubmit(e) {
+    e.preventDefault();
+
+    const tags = this.selected;
+
+    if (this.attrs.resolve) this.attrs.resolve(tags);
+
+    this.hide();
+  }
+}

--- a/js/src/forum/notifications/PrivateDiscussionMadePublicNotification.js
+++ b/js/src/forum/notifications/PrivateDiscussionMadePublicNotification.js
@@ -1,0 +1,22 @@
+import app from 'flarum/forum/app';
+import Notification from 'flarum/components/Notification';
+
+export default class PrivateDiscussionMadePublicNotification extends Notification {
+  icon() {
+    return app.forum.attribute('byobu.icon-badge');
+  }
+
+  href() {
+    const notification = this.props.notification;
+    const discussion = notification.subject();
+
+    return app.route.discussion(discussion);
+  }
+
+  content() {
+    const user = this.props.notification.fromUser();
+    return app.translator.trans('fof-byobu.forum.notifications.pd_made_public_text', {
+      user: user,
+    });
+  }
+}

--- a/js/src/forum/notifications/index.js
+++ b/js/src/forum/notifications/index.js
@@ -5,12 +5,14 @@ import PrivateDiscussionNotification from './PrivateDiscussionNotification';
 import PrivateDiscussionRepliedNotification from './PrivateDiscussionReplyNotification';
 import PrivateDiscussionUserLeftNotification from './PrivateDiscussionUserLeftNotification';
 import PrivateDiscussionAddedNotification from './PrivateDiscussionAddedNotification';
+import PrivateDiscussionMadePublicNotification from './PrivateDiscussionMadePublicNotification';
 
 export default function () {
   app.notificationComponents.byobuPrivateDiscussionCreated = PrivateDiscussionNotification;
   app.notificationComponents.byobuPrivateDiscussionReplied = PrivateDiscussionRepliedNotification;
   app.notificationComponents.byobuRecipientRemoved = PrivateDiscussionUserLeftNotification;
   app.notificationComponents.byobuPrivateDiscussionAdded = PrivateDiscussionAddedNotification;
+  app.notificationComponents.byobuPrivateDiscussionMadePubic = PrivateDiscussionMadePublicNotification;
 
   grid();
 }

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -1,3 +1,10 @@
 .ByobuSettingsPage {
-    margin-top: 25px;
+    margin-top: 15px;
+
+    @media @desktop-up {
+        .container {
+          max-width: 600px;
+          margin: 0;
+        }
+    }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -10,6 +10,7 @@ fof-byobu:
             edit_recipients: Edit Recipients
             send_pd: "Send {username} a message"
             cancel: Cancel
+            make_public: Make this discussion public
             remove_from_discussion: Leave this private discussion
 
         composer_private_discussion:
@@ -49,6 +50,7 @@ fof-byobu:
             recipients_modified:
                 added_and_removed: "{username} added recipients {added} and removed {removed}."
                 added: "{username} added recipients {added}."
+                made_public: "{username} removed all recipients and made the discussion public"
                 removed: "{username} removed recipients {removed}."
                 removed_self: "{username} left the private discussion."
 
@@ -75,6 +77,7 @@ fof-byobu:
             create_private_discussions_with_blocking_users: Create private discussions with users that block it
             edit_user_recipients: Edit users partaking in private discussions
             edit_group_recipients: Edit groups partaking in private discussions
+            make_private_into_public: Transform a private discussion into a public discussion
             view_private_discussions-when-flagged: View private discussions of other users if flagged
 
         settings:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -17,6 +17,9 @@ fof-byobu:
             submit_button: Post Private Discussion
             title_placeholder: Private Discussion Title
 
+        confirm:
+            make_public: Are you sure you want to remove the recipients and make this discussion visible to anyone who can view the assigned tag?
+
         labels:
             recipients: "{count, plural, one {{count} Recipient} other {{count} Recipients}}"
 
@@ -82,6 +85,8 @@ fof-byobu:
 
         settings:
             badge-icon: Byobu Discussion Badge
+            enable-make-public-option: Enable the "make public" ability
+            enable-make-public-option-help: Adds the ability for those with permission to remove all recipients, assign a new tag and make the discussion publically visible (accoring to the visibility settings of the chosen tag).
             post-event-icon: Byobu Post Events
 
     email:

--- a/resources/views/emails/byobuMadePublic.blade.php
+++ b/resources/views/emails/byobuMadePublic.blade.php
@@ -1,0 +1,6 @@
+{!! $translator->trans('fof-byobu.email.body.made_public', [
+    '{recipient_display_name}' => $user->display_name,
+    '{actor_display_name}' => $blueprint->actor->display_name,
+    '{discussion_title}' => $blueprint->discussion->title,
+    '{discussion_url}' => $url->to('forum')->route('discussion', ['id' => $blueprint->discussion->id]),
+]) !!}

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -12,6 +12,7 @@
 namespace FoF\Byobu\Access;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Access\AbstractPolicy;
 use Flarum\User\User;
 use FoF\Byobu\Database\RecipientsConstraint;
@@ -93,5 +94,16 @@ class DiscussionPolicy extends AbstractPolicy
         $screener = $screener->fromDiscussion($discussion);
 
         return $screener->isPrivate();
+    }
+
+    public function transformToPublic(User $actor, Discussion $discussion)
+    {
+        /** @var SettingsRepositoryInterface $settings */
+        $settings = resolve('flarum.settings');
+        if (! (bool)$settings->get('fof-byobu.makePublic')) {
+            return $this->deny();
+        }
+
+        return $actor->can('makePublic', $discussion);
     }
 }

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -100,7 +100,7 @@ class DiscussionPolicy extends AbstractPolicy
     {
         /** @var SettingsRepositoryInterface $settings */
         $settings = resolve('flarum.settings');
-        if (! (bool)$settings->get('fof-byobu.makePublic')) {
+        if (!(bool) $settings->get('fof-byobu.makePublic')) {
             return $this->deny();
         }
 

--- a/src/Api/DiscussionPermissionAttributes.php
+++ b/src/Api/DiscussionPermissionAttributes.php
@@ -21,16 +21,16 @@ class DiscussionPermissionAttributes
      * @var Screener
      */
     protected $screener;
-    
+
     public function __construct(Screener $screener)
     {
         $this->screener = $screener;
     }
-    
+
     /**
      * @param \Flarum\Api\Serializer\UserSerializer $serializer
      * @param \Flarum\Discussion\Discussion         $discussion
-     * @param array                                $attributes
+     * @param array                                 $attributes
      *
      * @return array
      */

--- a/src/Api/DiscussionPermissionAttributes.php
+++ b/src/Api/DiscussionPermissionAttributes.php
@@ -13,17 +13,28 @@ namespace FoF\Byobu\Api;
 
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
+use FoF\Byobu\Discussion\Screener;
 
 class DiscussionPermissionAttributes
 {
     /**
-     * @param Flarum\Api\Serializer\UserSerializer $serializer
-     * @param Flarum\Discussion\Discussion         $discussion
+     * @var Screener
+     */
+    protected $screener;
+    
+    public function __construct(Screener $screener)
+    {
+        $this->screener = $screener;
+    }
+    
+    /**
+     * @param \Flarum\Api\Serializer\UserSerializer $serializer
+     * @param \Flarum\Discussion\Discussion         $discussion
      * @param array                                $attributes
      *
-     * @return mixed
+     * @return array
      */
-    public function __invoke(DiscussionSerializer $serializer, Discussion $model, array $attributes)
+    public function __invoke(DiscussionSerializer $serializer, Discussion $model, array $attributes): array
     {
         $actor = $serializer->getActor();
         $users = $actor->can('editUserRecipients', $model);
@@ -32,6 +43,10 @@ class DiscussionPermissionAttributes
         $attributes['canEditRecipients'] = $users || $groups;
         $attributes['canEditUserRecipients'] = $users;
         $attributes['canEditGroupRecipients'] = $groups;
+
+        if ($this->screener->fromDiscussion($model)->isPrivate()) {
+            $attributes['canMakePublic'] = $actor->can('transformToPublic', $model);
+        }
 
         return $attributes;
     }

--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -159,4 +159,18 @@ class Screener extends Fluent
 
         return true;
     }
+
+    public function makingPublic(): bool
+    {
+        $id = Arr::get($this->event->data, 'attributes.public');
+
+        //dd($id, $this->event->data);
+        
+
+        if ($id && (int) $id === $this->event->discussion->id) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -165,7 +165,6 @@ class Screener extends Fluent
         $id = Arr::get($this->event->data, 'attributes.public');
 
         //dd($id, $this->event->data);
-        
 
         if ($id && (int) $id === $this->event->discussion->id) {
             return true;

--- a/src/Discussion/Screener.php
+++ b/src/Discussion/Screener.php
@@ -164,8 +164,6 @@ class Screener extends Fluent
     {
         $id = Arr::get($this->event->data, 'attributes.public');
 
-        //dd($id, $this->event->data);
-
         if ($id && (int) $id === $this->event->discussion->id) {
             return true;
         }

--- a/src/Events/DiscussionMadePublic.php
+++ b/src/Events/DiscussionMadePublic.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Events;
+
+class DiscussionMadePublic extends AbstractRecipientsEvent
+{
+}

--- a/src/Events/DiscussionMadePublic.php
+++ b/src/Events/DiscussionMadePublic.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/byobu.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Jobs/SendNotificationWhenDiscussionMadePublic.php
+++ b/src/Jobs/SendNotificationWhenDiscussionMadePublic.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Jobs;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\User\User;
+use FoF\Byobu\Notifications\DiscussionMadePublicBlueprint;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class SendNotificationWhenDiscussionMadePublic implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @var User
+     */
+    protected $actor;
+
+    /**
+     * @var Discussion
+     */
+    protected $discussion;
+
+    /**
+     * @var Collection
+     */
+    protected $newUsers;
+
+    /**
+     * @var Collection
+     */
+    protected $oldUsers;
+
+    public function __construct(
+        User $actor,
+        Discussion $discussion,
+        Collection $oldUsers
+    ) {
+        $this->actor = $actor;
+        $this->discussion = $discussion;
+        $this->oldUsers = $oldUsers;
+    }
+
+    public function handle(NotificationSyncer $notifications)
+    {
+        $recipients = $this->oldUsers->reject(function ($user) {
+            return $user->id === $this->actor->id;
+        });
+
+        $notifications->sync(new DiscussionMadePublicBlueprint($this->actor, $this->discussion), $recipients->all());
+    }
+}

--- a/src/Listeners/CreatePostWhenRecipientsChanged.php
+++ b/src/Listeners/CreatePostWhenRecipientsChanged.php
@@ -16,6 +16,7 @@ use FoF\Byobu\Events\Created;
 use FoF\Byobu\Events\DiscussionMadePublic;
 use FoF\Byobu\Events\RecipientsChanged;
 use FoF\Byobu\Events\RemovedSelf;
+use FoF\Byobu\Posts\MadePublic;
 use FoF\Byobu\Posts\RecipientLeft;
 use FoF\Byobu\Posts\RecipientsModified;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -28,7 +29,7 @@ class CreatePostWhenRecipientsChanged
     public function subscribe(Dispatcher $events)
     {
         $events->listen(Created::class, [$this, 'whenDiscussionWasTagged']);
-        $events->listen(DiscussionMadePublic::class, [$this, 'whenDiscussionWasTagged']);
+        $events->listen(DiscussionMadePublic::class, [$this, 'whenMadePublic']);
         $events->listen(RecipientsChanged::class, [$this, 'whenDiscussionWasTagged']);
         $events->listen(RemovedSelf::class, [$this, 'whenActorRemovedSelf']);
     }
@@ -46,6 +47,13 @@ class CreatePostWhenRecipientsChanged
     public function whenActorRemovedSelf(RemovedSelf $event)
     {
         $post = RecipientLeft::reply($event);
+
+        $event->discussion->mergePost($post);
+    }
+
+    public function whenMadePublic(DiscussionMadePublic $event)
+    {
+        $post = MadePublic::reply($event);
 
         $event->discussion->mergePost($post);
     }

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -89,7 +89,7 @@ class PersistRecipients
 
         $event->discussion->afterSave(function (Discussion $discussion) {
             foreach (['users', 'groups'] as $type) {
-                $relation = 'recipient' . Str::ucfirst($type);
+                $relation = 'recipient'.Str::ucfirst($type);
 
                 // Add models that weren't stored yet.
                 $discussion->{$relation}()->saveMany(

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -50,7 +50,7 @@ class PersistRecipients
             throw new PermissionDeniedException('Not allowed to add users that blocked receiving private discussions');
         }
 
-        if ($event->actor->cannot('makePublic', $event->discussion) && $this->screener->makingPublic()) {
+        if ($event->actor->cannot('transformToPublic', $event->discussion) && $this->screener->makingPublic()) {
             throw new PermissionDeniedException('Not allowed to convert to a public discussion');
         }
 

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -50,6 +50,10 @@ class PersistRecipients
             throw new PermissionDeniedException('Not allowed to add users that blocked receiving private discussions');
         }
 
+        if ($event->actor->cannot('makePublic', $event->discussion) && $this->screener->makingPublic()) {
+            throw new PermissionDeniedException('Not allowed to convert to a public discussion');
+        }
+
         if (!$event->discussion->exists) {
             $this->checkPermissionsForNewDiscussion($event->actor);
             $event->discussion->isByobu = true;
@@ -66,9 +70,10 @@ class PersistRecipients
         // now by default will be soft deleted/hidden.
         // The Deleting event is dispatched, if a listener interferes by returning
         // a non-null response the discussion will not be soft deleted.
-        if ($this->screener->wasPrivate() && !$this->screener->isPrivate()) {
+        if ($this->screener->wasPrivate() && !$this->screener->isPrivate() && !$this->screener->makingPublic()) {
             /** @var Dispatcher $events */
             $events = resolve(Dispatcher::class);
+
             $eventArgs = $this->eventArguments($event->discussion);
 
             if ($events->until(new Events\Deleting(...$eventArgs)) === null) {
@@ -84,7 +89,7 @@ class PersistRecipients
 
         $event->discussion->afterSave(function (Discussion $discussion) {
             foreach (['users', 'groups'] as $type) {
-                $relation = 'recipient'.Str::ucfirst($type);
+                $relation = 'recipient' . Str::ucfirst($type);
 
                 // Add models that weren't stored yet.
                 $discussion->{$relation}()->saveMany(
@@ -116,6 +121,8 @@ class PersistRecipients
 
         if ($this->screener->isPrivate() && !$discussion->exists) {
             $event = new Events\Created(...$args);
+        } elseif ($this->screener->makingPublic()) {
+            $event = new Events\DiscussionMadePublic(...$args);
         } elseif ($this->screener->actorRemoved()) {
             $event = new Events\RemovedSelf(...$args);
         } else {

--- a/src/Listeners/QueueNotificationJobs.php
+++ b/src/Listeners/QueueNotificationJobs.php
@@ -13,6 +13,7 @@ namespace FoF\Byobu\Listeners;
 
 use Flarum\Post\Event\Saving;
 use FoF\Byobu\Events\Created;
+use FoF\Byobu\Events\DiscussionMadePublic;
 use FoF\Byobu\Events\RecipientsChanged;
 use FoF\Byobu\Events\RemovedSelf;
 use FoF\Byobu\Jobs;
@@ -27,6 +28,7 @@ class QueueNotificationJobs
         $events->listen(Saving::class, [$this, 'postMadeInPrivateDiscussion']);
         $events->listen(RemovedSelf::class, [$this, 'discussionRecipientRemovedSelf']);
         $events->listen(RecipientsChanged::class, [$this, 'discussionRecipientsChanged']);
+        $events->listen(DiscussionMadePublic::class, [$this, 'discussionMadePublic']);
     }
 
     public function discussionMadePrivate(Created $event)
@@ -84,6 +86,13 @@ class QueueNotificationJobs
                 $event->screener->users,
                 $event->screener->currentUsers
             )
+        );
+    }
+
+    public function discussionMadePublic(DiscussionMadePublic $event)
+    {
+        resolve('flarum.queue.connection')->push(
+            new Jobs\SendNotificationWhenDiscussionMadePublic($event->actor, $event->discussion, $event->screener->users)
         );
     }
 }

--- a/src/Notifications/DiscussionMadePublicBlueprint.php
+++ b/src/Notifications/DiscussionMadePublicBlueprint.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Notifications;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
+use Flarum\User\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DiscussionMadePublicBlueprint implements BlueprintInterface, MailableInterface
+{
+    /**
+     * @var User
+     *           The user that was removed from the private discussion.
+     */
+    public $actor;
+
+    /**
+     * @var Discussion
+     */
+    public $discussion;
+
+    protected $sender;
+
+    public function __construct(User $actor, Discussion $discussion)
+    {
+        $this->actor = $actor;
+        $this->discussion = $discussion;
+    }
+
+    /**
+     * Get the user that sent the notification.
+     *
+     * @return \Flarum\User\User|null
+     */
+    public function getFromUser(): ?User
+    {
+        return $this->actor;
+    }
+
+    /**
+     * Get the model that is the subject of this activity.
+     *
+     * @return \Flarum\Database\AbstractModel|null
+     */
+    public function getSubject(): ?Discussion
+    {
+        return $this->discussion;
+    }
+
+    /**
+     * Get the data to be stored in the notification.
+     *
+     * @return array|null
+     */
+    public function getData()
+    {
+        // return [
+        //     'user_left'  => $this->user->id,
+        //     'discussion' => $this->discussion->id,
+        // ];
+        return [];
+    }
+
+    /**
+     * Get the serialized type of this activity.
+     *
+     * @return string
+     */
+    public static function getType()
+    {
+        return 'byobuMadePublic';
+    }
+
+    /**
+     * Get the name of the model class for the subject of this activity.
+     *
+     * @return string
+     */
+    public static function getSubjectModel()
+    {
+        return Discussion::class;
+    }
+
+    /**
+     * Get the name of the view to construct a notification email with.
+     *
+     * @return string
+     */
+    public function getEmailView()
+    {
+        return ['text' => 'fof-byobu::emails.byobuMadePublic'];
+    }
+
+    /**
+     * Get the subject line for a notification email.
+     *
+     * @return string
+     */
+    public function getEmailSubject(TranslatorInterface $translator)
+    {
+        return $translator->trans('fof-byobu.email.subject.made_public', [
+            '{display_name}'    => $this->actor->display_name,
+            '{title}'           => $this->discussion->title,
+        ]);
+    }
+}

--- a/src/Posts/MadePublic.php
+++ b/src/Posts/MadePublic.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Posts;
+
+use Flarum\Post\AbstractEventPost;
+use Flarum\Post\MergeableInterface;
+use Flarum\Post\Post;
+use FoF\Byobu\Events\AbstractRecipientsEvent;
+
+/**
+ * @property array $content
+ */
+class MadePublic extends AbstractEventPost implements MergeableInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static $type = 'madePublic';
+
+    /**
+     * @param Post|null|RecipientLeft $previous
+     *
+     * @return $this|RecipientsLef|Post
+     */
+    public function saveAfter(Post $previous = null)
+    {
+        /** @var RecipientLeft $previous */
+        if ($previous instanceof static) {
+            // .. @todo
+        }
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * Create a new instance in reply to a discussion.
+     *
+     * @param AbstractRecipientsEvent $event
+     *
+     * @return static
+     */
+    public static function reply(AbstractRecipientsEvent $event)
+    {
+        $post = new static();
+
+        $post->content = [];
+        $post->created_at = time();
+        $post->discussion_id = $event->discussion->id;
+        $post->user_id = $event->actor->id;
+
+        return $post;
+    }
+}


### PR DESCRIPTION
Reintroduces the ability to convert a private discussion to a public (subject to any tag restrictions) discussion.

- Setting to completely disable the feature, even for admins
- New post event type
- Workaround for missing icons due to empty settings values
- Prompt to select tags when making a discussion public
