### PR TITLE
Fix index down migration

### DIFF
--- a/migrations/2021_01_13_000000_unified_index_index.php
+++ b/migrations/2021_01_13_000000_unified_index_index.php
@@ -27,7 +27,7 @@ return [
 
             // If migration 2021_04_21_000000_drop_users_unified_index_column has been applied, this index already no longer exists
             // Unfortunately we can't call the protected createIndexName method so we have to build the index name manually
-            $indexName = strtolower(str_replace(['-', '.'], '_', $connection->getTablePrefix() . $table->getTable()) . '_unified_index_with_byobu_index');
+            $indexName = strtolower(str_replace(['-', '.'], '_', $connection->getTablePrefix().$table->getTable()).'_unified_index_with_byobu_index');
 
             if (!Arr::exists($existingIndexes, $indexName)) {
                 return;

--- a/migrations/2021_01_13_000000_unified_index_index.php
+++ b/migrations/2021_01_13_000000_unified_index_index.php
@@ -11,6 +11,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Arr;
 
 return [
     'up' => function (Builder $schema) {
@@ -19,7 +20,19 @@ return [
         });
     },
     'down' => function (Builder $schema) {
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', function (Blueprint $table) use ($schema) {
+            $connection = $schema->getConnection();
+            $schemaManager = $connection->getDoctrineSchemaManager();
+            $existingIndexes = $schemaManager->listTableIndexes($table->getTable());
+
+            // If migration 2021_04_21_000000_drop_users_unified_index_column has been applied, this index already no longer exists
+            // Unfortunately we can't call the protected createIndexName method so we have to build the index name manually
+            $indexName = strtolower(str_replace(['-', '.'], '_', $connection->getTablePrefix() . $table->getTable()) . '_unified_index_with_byobu_index');
+
+            if (!Arr::exists($existingIndexes, $indexName)) {
+                return;
+            }
+
             // Use array syntax so the blueprint "guesses" the full index name
             $table->dropIndex(['unified_index_with_byobu']);
         });


### PR DESCRIPTION
**Fixes #160**

The error happens because the down migration of `2021_04_21_000000_drop_users_unified_index_column` re-creates the column but not the index, and `2021_01_13_000000_unified_index_index` always tries to delete the index.

We could just completely drop the down migration of `2021_01_13_000000_unified_index_index`. I think the index would get dropped when the column is deleted again by `2020_10_23_000000_users_unified_index_column`. But this PR does it in the cleanest way I could think of.

**Confirmed**

Tested migrations up and down locally both with and without `2021_04_21_000000_drop_users_unified_index_column` to account for index existence or not.

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
