### PR TITLE
feat: add option to hard delete PD when all recipients have left

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -130,7 +130,8 @@ return [
         ->listen(UserSaving::class, Listeners\SaveUserPreferences::class)
         ->listen(DiscussionWasSplit::class, Listeners\AddRecipientsToSplitDiscussion::class)
         ->subscribe(Listeners\CreatePostWhenRecipientsChanged::class)
-        ->subscribe(Listeners\QueueNotificationJobs::class),
+        ->subscribe(Listeners\QueueNotificationJobs::class)
+        ->subscribe(Listeners\AllRecipientsLeftHandler::class),
 
     (new Extend\ServiceProvider())
         ->register(Provider\ByobuProvider::class),
@@ -153,5 +154,6 @@ return [
         })
         ->serializeToForum('byobu.icon-postAction', 'fof-byobu.icon-postAction', function ($value): string {
             return empty($value) ? 'far fa-map' : $value;
-        }),
+        })
+        ->default('fof-byobu.delete_on_last_recipient_left', false),
 ];

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1556,23 +1556,56 @@
             "version": "1.0.0",
             "license": "MIT"
         },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.0.5",
-            "license": "MIT",
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.11",
-            "license": "MIT"
+            "version": "1.4.14",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.4",
-            "license": "MIT",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
             "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
         "node_modules/@polka/url": {
@@ -2457,8 +2490,9 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "1.4.0",
-            "license": "MIT",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -2887,12 +2921,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.12.0",
-            "license": "BSD-2-Clause",
+            "version": "5.16.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
+            "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
             "dependencies": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "bin": {
@@ -2955,13 +2990,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/terser/node_modules/source-map": {
-            "version": "0.7.3",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/to-fast-properties": {

--- a/js/src/admin/components/ByobuSettingsPage.tsx
+++ b/js/src/admin/components/ByobuSettingsPage.tsx
@@ -53,6 +53,12 @@ export default class ByobuSetingsPage extends ExtensionPage {
                 label: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option'),
                 help: app.translator.trans('fof-byobu.admin.settings.enable-make-public-option-help'),
               })}
+              {this.buildSettingComponent({
+                type: 'boolean',
+                setting: 'fof-byobu.delete_on_last_recipient_left',
+                label: app.translator.trans('fof-byobu.admin.settings.delete_on_last_recipient_left'),
+                help: app.translator.trans('fof-byobu.admin.settings.delete_on_last_recipient_left_help'),
+              })}
             </div>
             <div className="Form-group">{this.submitButton()}</div>
           </div>

--- a/js/src/forum/extend/Discussion.js
+++ b/js/src/forum/extend/Discussion.js
@@ -92,7 +92,36 @@ function controls() {
         Button.component(
           {
             icon: app.forum.data.attributes['byobu.icon-badge'],
-            onclick: () => app.modal.show(AddRecipientModal, { discussion }),
+            onclick: () =>
+              app.modal.show(AddRecipientModal, {
+                discussion,
+                /**
+                 * @param {ItemList<User | Group>} recipients
+                 */
+                onsubmit(recipients) {
+                  if (recipients.isEmpty()) {
+                    // The discussion might have been perma-deleted! Let's check...
+                    app.store
+                      .find(
+                        'discussions',
+                        discussion.id(),
+                        {},
+                        {
+                          errorHandler(err) {
+                            if (err.status === 404) {
+                              // Almost certainly permadeleted, so let's just redirect to the PD list.
+                              m.route.set(app.route('byobuPrivate'));
+                            }
+                          },
+                        }
+                      )
+                      .catch((err) => {
+                        // some other error... assume not deleted
+                        console.error(err);
+                      });
+                  }
+                },
+              }),
           },
           app.translator.trans('fof-byobu.forum.buttons.edit_recipients')
         )

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -88,6 +88,8 @@ fof-byobu:
             enable-make-public-option: Enable the "make public" ability
             enable-make-public-option-help: Adds the ability for those with permission to remove all recipients, assign a new tag and make the discussion publically visible (accoring to the visibility settings of the chosen tag).
             post-event-icon: Byobu Post Events
+            delete_on_last_recipient_left: Delete PDs when the last user leaves
+            delete_on_last_recipient_left_help: If enabled, PDs will be permanently deleted from the database when the last user leaves. Otherwise, the PD will be soft-deleted/hidden.
 
     email:
         subject:

--- a/src/Events/AllRecipientsLeft.php
+++ b/src/Events/AllRecipientsLeft.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Events;
+
+use Flarum\Discussion\Discussion;
+use Flarum\User\User;
+
+class AllRecipientsLeft extends AbstractRecipientsEvent
+{
+    /**
+     * @var Discussion
+     */
+    public $discussion;
+
+    /**
+     * @var User
+     */
+    public $actor;
+
+    public function __construct(Discussion $discussion, User $actor)
+    {
+        $this->discussion = $discussion;
+        $this->actor = $actor;
+    }
+}

--- a/src/Listeners/AllRecipientsLeftHandler.php
+++ b/src/Listeners/AllRecipientsLeftHandler.php
@@ -11,9 +11,9 @@
 
 namespace FoF\Byobu\Listeners;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Discussion\Event\Deleting as DiscussionDeleting;
 use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Byobu\Events\AllRecipientsLeft;
 use Illuminate\Contracts\Events\Dispatcher;
 

--- a/src/Listeners/AllRecipientsLeftHandler.php
+++ b/src/Listeners/AllRecipientsLeftHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Byobu\Listeners;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Discussion\Event\Deleting as DiscussionDeleting;
+use Flarum\Foundation\DispatchEventsTrait;
+use FoF\Byobu\Events\AllRecipientsLeft;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class AllRecipientsLeftHandler
+{
+    use DispatchEventsTrait;
+
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings, Dispatcher $events)
+    {
+        $this->settings = $settings;
+        $this->events = $events;
+    }
+
+    /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(AllRecipientsLeft::class, [$this, 'whenAllRecipientsHaveLeft']);
+    }
+
+    public function whenAllRecipientsHaveLeft(AllRecipientsLeft $event)
+    {
+        // Once the discussion is hidden, we should check if we're meant to
+        // fully delete the PD. If so, hard delete it.
+        if (boolval($this->settings->get('fof-byobu.delete_on_last_recipient_left'))) {
+            $this->events->dispatch(
+                new DiscussionDeleting($event->discussion, $event->actor)
+            );
+
+            $event->discussion->delete();
+
+            $this->dispatchEventsFor($event->discussion, $event->actor);
+        }
+    }
+}

--- a/src/Listeners/CreatePostWhenRecipientsChanged.php
+++ b/src/Listeners/CreatePostWhenRecipientsChanged.php
@@ -41,6 +41,8 @@ class CreatePostWhenRecipientsChanged
     {
         $post = RecipientsModified::reply($event);
 
+        if (!$event->discussion->exists) return;
+
         $event->discussion->mergePost($post);
     }
 
@@ -48,12 +50,16 @@ class CreatePostWhenRecipientsChanged
     {
         $post = RecipientLeft::reply($event);
 
+        if (!$event->discussion->exists) return;
+
         $event->discussion->mergePost($post);
     }
 
     public function whenMadePublic(DiscussionMadePublic $event)
     {
         $post = MadePublic::reply($event);
+
+        if (!$event->discussion->exists) return;
 
         $event->discussion->mergePost($post);
     }

--- a/src/Listeners/CreatePostWhenRecipientsChanged.php
+++ b/src/Listeners/CreatePostWhenRecipientsChanged.php
@@ -41,7 +41,9 @@ class CreatePostWhenRecipientsChanged
     {
         $post = RecipientsModified::reply($event);
 
-        if (!$event->discussion->exists) return;
+        if (!$event->discussion->exists) {
+            return;
+        }
 
         $event->discussion->mergePost($post);
     }
@@ -50,7 +52,9 @@ class CreatePostWhenRecipientsChanged
     {
         $post = RecipientLeft::reply($event);
 
-        if (!$event->discussion->exists) return;
+        if (!$event->discussion->exists) {
+            return;
+        }
 
         $event->discussion->mergePost($post);
     }
@@ -59,7 +63,9 @@ class CreatePostWhenRecipientsChanged
     {
         $post = MadePublic::reply($event);
 
-        if (!$event->discussion->exists) return;
+        if (!$event->discussion->exists) {
+            return;
+        }
 
         $event->discussion->mergePost($post);
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Add option to auto-delete a PD when all recipients leave

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![](https://user-images.githubusercontent.com/7406822/204376342-e9bae689-a24f-412b-ad28-e531c4cc2302.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
