### PR TITLE
Setting to hide PDs from "all discussions" page

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -14,6 +14,7 @@ namespace FoF\Byobu;
 use Flarum\Api\Controller;
 use Flarum\Api\Serializer;
 use Flarum\Discussion\Discussion;
+use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use Flarum\Group\Group;
@@ -145,6 +146,9 @@ return [
 
     (new Extend\SimpleFlarumSearch(UserSearcher::class))
         ->addGambit(Gambits\User\AllowsPdGambit::class),
+
+    (new Extend\Filter(DiscussionFilterer::class))
+        ->addFilterMutator(Filters\Discussion\HidePrivateDiscussionsFromAllDiscussionsPage::class),
 
     (new Extend\Settings())
         // we have to use the callback here, else we risk returning empty values instead of the defaults.

--- a/js/src/admin/components/ByobuSettingsPage.tsx
+++ b/js/src/admin/components/ByobuSettingsPage.tsx
@@ -59,6 +59,12 @@ export default class ByobuSetingsPage extends ExtensionPage {
                 label: app.translator.trans('fof-byobu.admin.settings.delete_on_last_recipient_left'),
                 help: app.translator.trans('fof-byobu.admin.settings.delete_on_last_recipient_left_help'),
               })}
+              {this.buildSettingComponent({
+                type: 'boolean',
+                setting: 'fof-byobu.hide_from_all_discussions_page',
+                label: app.translator.trans('fof-byobu.admin.settings.hide_from_all_discussions_page'),
+                help: app.translator.trans('fof-byobu.admin.settings.hide_from_all_discussions_page_help'),
+              })}
             </div>
             <div className="Form-group">{this.submitButton()}</div>
           </div>

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -90,6 +90,8 @@ fof-byobu:
             post-event-icon: Byobu Post Events
             delete_on_last_recipient_left: Delete PDs when the last user leaves
             delete_on_last_recipient_left_help: If enabled, PDs will be permanently deleted from the database when the last user leaves. Otherwise, the PD will be soft-deleted/hidden.
+            hide_from_all_discussions_page: Hide PDs from "All Discussions" page
+            hide_from_all_discussions_page_help: Private discussions will only be accessible from the "Private Discussions" page or the user profile
 
     email:
         subject:

--- a/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
+++ b/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FoF\Byobu\Filters\Discussion;
+
+use Flarum\Filter\FilterState;
+use Flarum\Query\QueryCriteria;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class HidePrivateDiscussionsFromAllDiscussionsPage
+{
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function __invoke(FilterState $filter, QueryCriteria $queryCriteria)
+    {
+        if (
+            // If there are filters applied, we are no longer on "all discussions" page and don't want to restrict
+            count($filter->getActiveFilters()) > 0 ||
+            // If the user is logged out, they can't have private discussions anyway so we can skip the costly computations that follow
+            $filter->getActor()->isGuest() ||
+            // Finally, check if this feature is enabled
+            !$this->settings->get('fof-byobu.hide_from_all_discussions_page')) {
+            return;
+        }
+
+        // Use a JOIN instead of a subquery because we don't want to extract the list of all PD IDs from the entire forum
+        // Use an alias for the recipients table to avoir errors with other features or extension that might also join the table
+        $filter->getQuery()
+            ->leftJoin('recipients as adp_recipients', 'adp_recipients.discussion_id', '=', 'discussions.id')
+            ->whereNull('adp_recipients.discussion_id');
+    }
+}

--- a/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
+++ b/src/Filters/Discussion/HidePrivateDiscussionsFromAllDiscussionsPage.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/byobu.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Byobu\Filters\Discussion;
 
 use Flarum\Filter\FilterState;


### PR DESCRIPTION
**Changes proposed in this pull request:**
Allow hiding private discussions from the "All discussions" page. The private discussions remain visible in the "Private discussions" page and in the discussion list of a user profile.

This PR was sponsored by a client.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
