### PR TITLE
New permission controlling 2+ recipients PDs

### DIFF
--- a/js/src/admin/addPrivateDiscussionPermission.ts
+++ b/js/src/admin/addPrivateDiscussionPermission.ts
@@ -17,6 +17,16 @@ export default function () {
     .registerPermission(
       {
         icon: 'far fa-map',
+        label: app.translator.trans('fof-byobu.admin.permission.add_more_than_two_user_recipients'),
+        permission: 'discussion.addMoreThanTwoUserRecipients',
+        tagScoped: false,
+      },
+      'start',
+      95
+    )
+    .registerPermission(
+      {
+        icon: 'far fa-map',
         label: app.translator.trans('fof-byobu.admin.permission.create_private_discussions_with_groups'),
         permission: 'discussion.startPrivateDiscussionWithGroups',
         tagScoped: false,

--- a/js/src/forum/search/RecipientSearch.js
+++ b/js/src/forum/search/RecipientSearch.js
@@ -161,6 +161,19 @@ export default class RecipientSearch extends Search {
 
     let recipient = this.findRecipient(type, id);
 
+    // If the user is only allowed to add another recipient apart themselves
+    // We will remove all other users from the selection when a new value is picked
+    if (type === 'users' && !app.forum.attribute('canAddMoreThanTwoUserRecipients')) {
+      this.attrs
+        .selected()
+        .toArray()
+        .forEach((recipient) => {
+          if (recipient instanceof User && recipient.id() !== app.session.user?.id()) {
+            this.attrs.selected().remove('users:' + recipient.id());
+          }
+        });
+    }
+
     this.attrs.selected().add(value, recipient);
 
     this.searchState.clear();

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -76,6 +76,7 @@ fof-byobu:
     admin:
         permission:
             create_private_discussions_with_users: Create private discussions with users
+            add_more_than_two_user_recipients: Add more than 2 user recipients to private discussion
             create_private_discussions_with_groups: Create private discussions with groups
             create_private_discussions_with_blocking_users: Create private discussions with users that block it
             edit_user_recipients: Edit users partaking in private discussions

--- a/src/Api/ForumPermissionAttributes.php
+++ b/src/Api/ForumPermissionAttributes.php
@@ -30,6 +30,7 @@ class ForumPermissionAttributes
 
         $attributes['canStartPrivateDiscussion'] = $users || $groups;
         $attributes['canStartPrivateDiscussionWithUsers'] = $users;
+        $attributes['canAddMoreThanTwoUserRecipients'] = $actor->can('discussion.addMoreThanTwoUserRecipients');
         $attributes['canStartPrivateDiscussionWithGroups'] = $groups;
         $attributes['canStartPrivateDiscussionWithBlockers'] = $actor->can('discussion.startPrivateDiscussionWithBlockers');
 

--- a/src/Listeners/PersistRecipients.php
+++ b/src/Listeners/PersistRecipients.php
@@ -63,6 +63,10 @@ class PersistRecipients
             throw new PermissionDeniedException('Not allowed to convert to a public discussion');
         }
 
+        if ($event->actor->cannot('addMoreThanTwoUserRecipients', $event->discussion) && $this->screener->users->count() > 2) {
+            throw new PermissionDeniedException('Not allowed to add more than 2 user recipients');
+        }
+
         if (!$event->discussion->exists) {
             $this->checkPermissionsForNewDiscussion($event->actor);
             $event->discussion->isByobu = true;


### PR DESCRIPTION
**Changes proposed in this pull request:**
A new permission controls whether the user can add more than 2 user recipients to a discussion. This allows restricting the feature to simple direct messages and control who can create group discussions separately.

The texts in the recipients modal have not been modified, but if you try adding a third recipient to a new discussion and don't have the permission, the other recipient will be removed and the newly selected recipient added.

The permission only affects the **user** count. If the actor has permission to add groups, those are still unlimited and unaffected. It probably doesn't make sense to restrict user count while allowing groups but it'll work.

**Reviewers should focus on:**
This first version is not "backward compatible", users who update would lose functionality until they customize the new permission. I guess we should copy the value of `discussion.startPrivateDiscussionWithUsers` into `discussion.addMoreThanTwoUserRecipients` with a migration? The challenge is that if users forget to run the migrations they will encounter the issue anyway, and the migration needs to do nothing if run later, but has no way of knowing if the lack of value is indication of a choice for "admin" or that no choice was made...

I think there are also edge cases regarding leaving. You could add a "third" recipient at the same time as you remove yourself, which still meets the 2 recipients rule.

This PR was sponsored by a client.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
