### PR TITLE
fix: resolving dependencies in migrations is bad practice

### DIFF
--- a/migrations/2020_02_19_110103_remove_retired_settings_key.php
+++ b/migrations/2020_02_19_110103_remove_retired_settings_key.php
@@ -13,11 +13,11 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
-        $settings->delete('fof-byobu.enable_byobu_user_page');
+        $schema->getConnection()
+            ->query()
+            ->from('settings')
+            ->where('key', 'fof-byobu.enable_byobu_user_page')
+            ->delete();
     },
 
     'down' => function (Builder $schema) {


### PR DESCRIPTION
Using the container within migrations prevents the ability to run those migrations on first installs. For example, this gets in the way of migrating database formats to Flarum.

Should always use the database connection directly to apply changes.